### PR TITLE
Correct root path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y nginx
 
 ENV TERM=xterm
-ENV ROOT /var/www/react-starter-app
+ENV ROOT /var/www/redux-in-docker
 
 # make this cache-able
 RUN mkdir -p $ROOT/dist && \


### PR DESCRIPTION
Path didn't match the volume on the docker-compose.yml.
So currently, hot reload doesn't work at all.